### PR TITLE
Fix object id not a function on ViewerType

### DIFF
--- a/graphql/type/ViewerType.js
+++ b/graphql/type/ViewerType.js
@@ -19,7 +19,7 @@ export default new GraphQLObjectType( {
   fields: {
     id: globalIdField('Viewer'),
 
-    User_IsAnonymous:  { type: GraphQLBoolean, resolve: (obj) => obj.id.equals( Uuid_0 ) },
+    User_IsAnonymous:  { type: GraphQLBoolean, resolve: (obj) => obj.id == Uuid_0 },
     User_DisplayName:  { type: GraphQLString,  resolve: (obj) => obj.User_DisplayName },
     User_ProfilePhoto: { type: GraphQLString,  resolve: (obj) => obj.User_ProfilePhoto },
     User_Email:        { type: GraphQLString,  resolve: (obj) => obj.User_Email },


### PR DESCRIPTION
When creating a new user you can get authentication failures:

```
error: Server error: local network layer GraphQL failire errors=[message=obj.id.equals is not a function, ], _settled=true, _resolve=function (value) {
[1]     if (done) return;
[1]     done = true;
[1]     resolve(promise, value);
[1]   }, _reject=function (reason) {
[1]     if (done) return;
[1]     done = true;
[1]     reject(promise, reason);
[1]   }, _45=2, _81=2, , _54=null, text=query Routes{Viewer{id,...F0}} fragment F0 on Viewer{User_IsAnonymous,User_AuthToken,id}, , children=[fieldName=id, kind=Field, isGenerated=true, isRequisite=true, type=ID, , children=[fieldName=User_IsAnonymous, kind=Field, , type=Boolean, fieldName=User_AuthToken, kind=Field, , type=String, fieldName=id, kind=Field, isGenerated=true, isRequisite=true, type=ID], id=3::client, kind=Fragment, , name=Home_Screen_ViewerRelayQL, type=Viewer, $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"], name=$$_aggregated-$$_route[1]_@@default_Viewer-$$_route[2]_@@default_Viewer, , __calls__=null, __children__=[$ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][0], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["__cachedFragment__"]["__route__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["__cachedFragment__"]["__variables__"], __calls__=[], __children__=[], __fieldMap__=null, __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=User_IsAnonymous, __debugName__=undefined, __isRefQueryDependency__=false, __rangeBehaviorKey__=undefined, __shallowHash__=undefined, $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][1], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["__cachedFragment__"]["__route__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["__cachedFragment__"]["__variables__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["__cachedFragment__"]["__children__"][0]["__calls__"], __children__=[], __fieldMap__=null, __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=User_AuthToken, __debugName__=undefined, __isRefQueryDependency__=false, __rangeBehaviorKey__=undefined, __shallowHash__=undefined, $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][2], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["__cachedFragment__"]["__route__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["__cachedFragment__"]["__variables__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["__cachedFragment__"]["__children__"][0]["__calls__"], __children__=[], __fieldMap__=null, __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=id, __debugName__=undefined, __isRefQueryDependency__=false, __rangeBehaviorKey__=undefined, __shallowHash__=undefined], __fieldMap__=null, __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=null, __compositeHash__=_3::client4qRqOj, isDeferred=false, isContainerFragment=true, __cacheKey__=$$_aggregated-$$_route[1]_@@default_Viewer-$$_route[2]_@@default_Viewer:{}:{isContainerFragment:true,isDeferred:false}, _fragmentGetter=function () {
[1]       return buildContainerFragment(containerName, fragmentName, fragmentBuilder, initialVariables);
[1]     }, _isContainerFragment=true, _isDeferred=false, , _prepareVariables=undefined], fieldName=Viewer, kind=Query, , name=Routes, type=Viewer, $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["__cachedFragment__"]["__route__"], , __calls__=null, __children__=[$ref=$["request"]["_query"]["__concreteNode__"]["children"][0], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["__cachedFragment__"]["__route__"], $ref=$["request"]["_query"]["__variables__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["__cachedFragment__"]["__children__"][0]["__calls__"], __children__=[], __fieldMap__=null, __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=id, __debugName__=undefined, __isRefQueryDependency__=false, __rangeBehaviorKey__=undefined, __shallowHash__=undefined, $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["__cachedFragment__"]], __fieldMap__=null, __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=undefined, __batchCall__=null, __id__=q9, __identifyingArg__=undefined
[1] error: Server error: local network layer GraphQL failire errors=[message=obj.id.equals is not a function, ], _settled=true, _resolve=function (value) {
[1]     if (done) return;
[1]     done = true;
[1]     resolve(promise, value);
[1]   }, _reject=function (reason) {
[1]     if (done) return;
[1]     done = true;
[1]     reject(promise, reason);
[1]   }, _45=2, _81=2, , _54=null, text=query Routes{Viewer{id,...F2}} fragment F0 on Viewer{User_IsAnonymous,User_DisplayName,User_ProfilePhoto,id} fragment F1 on Viewer{ToDo_TotalCount,ToDo_CompletedCount,id} fragment F2 on Viewer{User_IsAnonymous,User_AuthToken,id,...F0,...F1}, , children=[fieldName=id, kind=Field, isGenerated=true, isRequisite=true, type=ID, , children=[fieldName=User_IsAnonymous, kind=Field, , type=Boolean, fieldName=User_AuthToken, kind=Field, , type=String, fieldName=id, kind=Field, isGenerated=true, isRequisite=true, type=ID, , children=[fieldName=User_IsAnonymous, kind=Field, , type=Boolean, fieldName=User_DisplayName, kind=Field, , type=String, fieldName=User_ProfilePhoto, kind=Field, , type=String, fieldName=id, kind=Field, isGenerated=true, isRequisite=true, type=ID], id=1::client, kind=Fragment, , name=AppBar_Auth_ViewerRelayQL, type=Viewer, $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"], name=$$_aggregated-$$_route[1]_@@default_Viewer-$$_route[2]_@@default_Viewer, , __calls__=null, __children__=[$ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["children"][0], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__route__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__variables__"], __calls__=[], __children__=[], __fieldMap__=null, __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=null, __debugName__=undefined, __isRefQueryDependency__=false, __rangeBehaviorKey__=undefined, __shallowHash__=undefined, $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["children"][1], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__route__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__variables__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__children__"][0]["__calls__"], __children__=[], __fieldMap__=null, __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=null, __debugName__=undefined, __isRefQueryDependency__=false, __rangeBehaviorKey__=undefined, __shallowHash__=undefined, $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["children"][2], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__route__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__variables__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__children__"][0]["__calls__"], __children__=[], __fieldMap__=null, __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=null, __debugName__=undefined, __isRefQueryDependency__=false, __rangeBehaviorKey__=undefined, __shallowHash__=undefined, $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["children"][3], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__route__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__variables__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__children__"][0]["__calls__"], __children__=[], __fieldMap__=null, __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=null, __debugName__=undefined, __isRefQueryDependency__=false, __rangeBehaviorKey__=undefined, __shallowHash__=undefined], __fieldMap__=null, __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=null, __compositeHash__=_1::client1hz3YB, isDeferred=false, isContainerFragment=true, __cacheKey__=$$_aggregated-$$_route[1]_@@default_Viewer-$$_route[2]_@@default_Viewer:{}:{isContainerFragment:true,isDeferred:false}, _fragmentGetter=function () {
[1]       return buildContainerFragment(containerName, fragmentName, fragmentBuilder, initialVariables);
[1]     }, _isContainerFragment=true, _isDeferred=false, _variableMapping=undefined, _prepareVariables=undefined, , children=[fieldName=ToDo_TotalCount, kind=Field, , type=Int, fieldName=ToDo_CompletedCount, kind=Field, , type=Int, fieldName=id, kind=Field, isGenerated=true, isRequisite=true, type=ID], id=2::client, kind=Fragment, , name=AppBar_ToDo_OpenIndicator_ViewerRelayQL, type=Viewer, $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][4]["_fragment"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__route__"], , __calls__=null, __children__=[$ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][4]["_fragment"]["children"][0], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__route__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][4]["_fragment"]["__cachedFragment__"]["__variables__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__children__"][0]["__calls__"], __children__=[], __fieldMap__=null, __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=null, __debugName__=undefined, __isRefQueryDependency__=false, __rangeBehaviorKey__=undefined, __shallowHash__=undefined, $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][4]["_fragment"]["children"][1], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__route__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][4]["_fragment"]["__cachedFragment__"]["__variables__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__children__"][0]["__calls__"], __children__=[], __fieldMap__=null, __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=null, __debugName__=undefined, __isRefQueryDependency__=false, __rangeBehaviorKey__=undefined, __shallowHash__=undefined, $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][4]["_fragment"]["children"][2], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__route__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][4]["_fragment"]["__cachedFragment__"]["__variables__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__children__"][0]["__calls__"], __children__=[], __fieldMap__=null, __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=null, __debugName__=undefined, __isRefQueryDependency__
[1] =false, __rangeBehaviorKey__=undefined, __shallowHash__=undefined], __fieldMap__=null, __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=null, __compositeHash__=_2::client34QT6M, isDeferred=false, isContainerFragment=true, __cacheKey__=$$_aggregated-$$_route[1]_@@default_Viewer-$$_route[2]_@@default_Viewer:{}:{isContainerFragment:true,isDeferred:false}, _fragmentGetter=function () {
[1]       return buildContainerFragment(containerName, fragmentName, fragmentBuilder, initialVariables);
[1]     }, _isContainerFragment=true, _isDeferred=false, _variableMapping=undefined, _prepareVariables=undefined], id=0::client, kind=Fragment, , name=Chrome_ViewerRelayQL, type=Viewer, $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__route__"], , __calls__=null, __children__=[$ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][0], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__route__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["__cachedFragment__"]["__variables__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__children__"][0]["__calls__"], __children__=[], __fieldMap__=null, __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=null, __debugName__=undefined, __isRefQueryDependency__=false, __rangeBehaviorKey__=undefined, __shallowHash__=undefined, $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][1], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__route__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["__cachedFragment__"]["__variables__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__children__"][0]["__calls__"], __children__=[], __fieldMap__=null, __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=null, __debugName__=undefined, __isRefQueryDependency__=false, __rangeBehaviorKey__=undefined, __shallowHash__=undefined, $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][2], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__route__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["__cachedFragment__"]["__variables__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__children__"][0]["__calls__"], __children__=[], __fieldMap__=null, __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=null, __debugName__=undefined, __isRefQueryDependency__=false, __rangeBehaviorKey__=undefined, __shallowHash__=undefined, $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][4]["_fragment"]["__cachedFragment__"]], __fieldMap__=null, __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=null, __compositeHash__=_0::clientvRwzs, isDeferred=false, isContainerFragment=true, __cacheKey__=$$_aggregated-$$_route[1]_@@default_Viewer-$$_route[2]_@@default_Viewer:{}:{isContainerFragment:true,isDeferred:false}, _fragmentGetter=function () {
[1]       return buildContainerFragment(containerName, fragmentName, fragmentBuilder, initialVariables);
[1]     }, _isContainerFragment=true, _isDeferred=false, , _prepareVariables=undefined], fieldName=Viewer, kind=Query, , name=Routes, type=Viewer, $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__route__"], , $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__children__"][0]["__calls__"], __children__=[$ref=$["request"]["_query"]["__concreteNode__"]["children"][0], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__route__"], $ref=$["request"]["_query"]["__variables__"], $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["children"][3]["_fragment"]["__cachedFragment__"]["__children__"][0]["__calls__"], __children__=[], __fieldMap__=null, __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=id, __debugName__=undefined, __isRefQueryDependency__=false, __rangeBehaviorKey__=undefined, __shallowHash__=undefined, $ref=$["request"]["_query"]["__concreteNode__"]["children"][1]["_fragment"]["__cachedFragment__"]], $ref=$["request"]["_query"]["__children__"][0], __hasDeferredDescendant__=false, __hasValidatedConnectionCalls__=null, __serializationKey__=null, __storageKey__=Viewer, __batchCall__=null, __id__=q8, __identifyingArg__=undefined
[1] Failed to execute query `Routes` for the following reasons:
[1] 
[1] 1. obj.id.equals is not a function
[1]    agment F0 on Viewer{User_IsAnonymous,User_AuthToken,id}
[1]                        ^^^
[1] Failed to execute query `Routes` for the following reasons:
[1] 
[1] 1. obj.id.equals is not a function
[1]    agment F2 on Viewer{User_IsAnonymous,User_AuthToken,id,...F0
[1]                        ^^^
[1]    agment F0 on Viewer{User_IsAnonymous,User_DisplayName,User_P
[1]                        ^^^
[1] Warning: RelayReadyState: Invalid state change from `{"aborted":false,"done":false,"error":{},"ready":false,"stale":false}` to `{"error":{}}`.
[1] /Users/justin/p/UniversalRelayBoilerplate/node_modules/promise/lib/done.js:10
[1]       throw err;
[1]       ^
[1] 
[1] Error: Can't set headers after they are sent.
[1]     at ServerResponse.OutgoingMessage.setHeader (_http_outgoing.js:346:11)
[1]     at ServerResponse.header (/Users/justin/p/UniversalRelayBoilerplate/node_modules/express/lib/response.js:718:10)
[1]     at ServerResponse.send (/Users/justin/p/UniversalRelayBoilerplate/node_modules/express/lib/response.js:163:12)
[1]     at serveFailure (renderOnServer.js:34:21)
[1]     at NetworkLayer.onError [as _onError] (renderOnServer.js:69:47)
[1]     at NetworkLayer._executeRequest$ (/Users/justin/p/UniversalRelayBoilerplate/node_modules/relay-local-schema/lib/NetworkLayer.js:69:18)
[1]     at tryCatch (/Users/justin/p/UniversalRelayBoilerplate/node_modules/relay-local-schema/node_modules/babel-runtime/regenerator/runtime.js:72:40)
[1]     at GeneratorFunctionPrototype.invoke [as _invoke] (/Users/justin/p/UniversalRelayBoilerplate/node_modules/relay-local-schema/node_modules/babel-runtime/regenerator/runtime.js:334:22)
[1]     at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/Users/justin/p/UniversalRelayBoilerplate/node_modules/relay-local-schema/node_modules/babel-runtime/regenerator/runtime.js:105:21)
[1]     at tryCatch (/Users/justin/p/UniversalRelayBoilerplate/node_modules/relay-local-schema/node_modules/babel-runtime/regenerator/runtime.js:72:40)
[1] [nodemon] app crashed - waiting for file changes before starting...
```