### PR TITLE
Wrong case on scripts/build-units.js

### DIFF
--- a/scripts/build-units.js
+++ b/scripts/build-units.js
@@ -254,8 +254,8 @@ function createViewerFields()
     '}'
   ] )
 
-  console.log( 'Written: ' + path.resolve( './configuration/graphql/_viewerFields.js' ) )
-  fs.writeFileSync( './configuration/graphql/_viewerFields.js', viewerFields.join( '\r\n' ), 'utf8' )
+  console.log( 'Written: ' + path.resolve( './configuration/graphql/_ViewerFields.js' ) )
+  fs.writeFileSync( './configuration/graphql/_ViewerFields.js', viewerFields.join( '\r\n' ), 'utf8' )
 }
 
 


### PR DESCRIPTION
Fix little wrong case on generated file name _ViewerFields in configuration by generator script.